### PR TITLE
Move eval/measure_judged.py improvements over to anserini-eval repo

### DIFF
--- a/measure_judged.py
+++ b/measure_judged.py
@@ -67,6 +67,8 @@ if __name__ == "__main__":
                         default=[5, 10, 20, 30],
                         help='Space-separate list of cutoffs. '
                              'E.g.: --cutoffs 5 10 20')
+    parser.add_argument('-q', action='store_true', dest='print_topic',
+                        help='In addition to summary evaluation, give evaluation for each query/topic')
 
     args = parser.parse_args()
 
@@ -79,9 +81,12 @@ if __name__ == "__main__":
         for query_id, doc_ids in run.items():
             doc_ids = doc_ids[:max_rank]
             n_judged = len(set(doc_ids).intersection(qrels[query_id]))
-            percentage_judged += n_judged / len(doc_ids)
+            percentage_judged_per_topic = n_judged / len(doc_ids)
+            if args.print_topic:
+                print(f'judged_cut_{max_rank}\t{query_id}\t{percentage_judged_per_topic:.4f}')
+            percentage_judged += percentage_judged_per_topic
 
         percentage_judged /= max(1, len(run))
-        print(f'judged@{max_rank}: {percentage_judged}')
+        print(f'judged_cut_{max_rank}\tall\t{percentage_judged:.4f}')
 
     print('\nDone')


### PR DESCRIPTION
Moving [changes](https://github.com/castorini/anserini/pull/1246) to measure_judged.py from anserini to here, as per https://github.com/castorini/anserini/issues/1247.

## Summary 

As per described in https://github.com/castorini/anserini/issues/1166
* Print percentage as 0.XXXX
* Added `-q` option to print per topic measurement

## Example

```
$ python eval/measure_judged.py --qrels src/main/resources/topics-and-qrels/qrels.covid-round12.txt --cutoffs 10 --run runs/anserini.covid-r3.abstract.qq.bm25.txt -q

judged_cut_10   1       0.1000
judged_cut_10   2       0.4000
...
judged_cut_10   40      0.0000
judged_cut_10   all     0.3300

Done
```
