### PR TITLE
[codex] Add TREC 7 and 8 topic aliases

### DIFF
--- a/topics-aliases.json
+++ b/topics-aliases.json
@@ -5,6 +5,12 @@
   "adhoc.151-200": [
     "trec3-adhoc"
   ],
+  "adhoc.351-400": [
+    "trec7-adhoc"
+  ],
+  "adhoc.401-450": [
+    "trec8-adhoc"
+  ],
   "adhoc.451-550": [
     "wt10g"
   ],

--- a/topics.json
+++ b/topics.json
@@ -7,6 +7,14 @@
     "path": "topics.adhoc.151-200.txt",
     "reader_class": "io.anserini.search.topicreader.TrecTopicReader"
   },
+  "adhoc.351-400": {
+    "path": "topics.adhoc.351-400.txt",
+    "reader_class": "io.anserini.search.topicreader.TrecTopicReader"
+  },
+  "adhoc.401-450": {
+    "path": "topics.adhoc.401-450.txt",
+    "reader_class": "io.anserini.search.topicreader.TrecTopicReader"
+  },
   "adhoc.451-550": {
     "path": "topics.adhoc.451-550.txt",
     "reader_class": "io.anserini.search.topicreader.TrecTopicReader"


### PR DESCRIPTION
## Summary

- Register `adhoc.351-400` and `adhoc.401-450` topic files.
- Add `trec7-adhoc` and `trec8-adhoc` aliases.
- Make the existing TREC 7 and TREC 8 topic files discoverable through canonical keys and aliases.

## Validation

- `jq empty topics.json topics-aliases.json`
- `test -f topics/topics.adhoc.351-400.txt`
- `test -f topics/topics.adhoc.401-450.txt`
- `git diff --check HEAD^ HEAD`
